### PR TITLE
Use consistent escape sequence on reset_colors

### DIFF
--- a/simple_curses.sh
+++ b/simple_curses.sh
@@ -192,7 +192,7 @@ window(){
 
 }
 reset_colors(){
-    echo -n -e "\E[00m"
+    echo -ne "\033[00m"
 }
 setcolor(){
     local color


### PR DESCRIPTION
All other color commands use `\033` as escape sequence, while `reset_colors` was using `\E`.