### PR TITLE
Progressbar: make len optional defaulting to fill all available space

### DIFF
--- a/simple_curses.sh
+++ b/simple_curses.sh
@@ -409,9 +409,9 @@ progressbar(){
     local max
     local bar
     local modulo
-    len=$1
-    progress=$2
-    max=$3
+    progress=$1
+    max=$2
+    len=${3:-$(( BSC_LASTCOLS - 6 ))}
     len=$(( len - 2 ))
     
     done=$(( progress * len / max))


### PR DESCRIPTION
:warning: This is breaking! It changes `progressbar` argument order

Make `len` optional and the third arg of `progressbar`, defaulting to fill all window space.