### PR TITLE
Add scrolling capability, help. Fixes, refactor.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Andrzej Bednarski - Fixes
 Laurent Bachelier - Patches
 alejandrogallo - Patches
 Markus Mikkolainen - Patches(update function,blinkenlights,vumeter,progressbar)
+Pierre Mazein - Add scrolling capability, fixes, help, doc

--- a/examples/bashbar.sh
+++ b/examples/bashbar.sh
@@ -40,4 +40,4 @@ main (){
     done
     endwin
 }
-main_loop 0.5
+main_loop -t 0.5 "$@"

--- a/examples/bashbar2.sh
+++ b/examples/bashbar2.sh
@@ -43,4 +43,4 @@ main (){
     done
     endwin
 }
-main_loop 0.5
+main_loop -t 0.5 $@

--- a/examples/progress.sh
+++ b/examples/progress.sh
@@ -19,4 +19,4 @@ update(){
     [ "$progress" -gt "$maxprogress" ] && return 255
     return 0
 }
-main_loop update
+main_loop "$@"

--- a/examples/vumeter.sh
+++ b/examples/vumeter.sh
@@ -20,4 +20,4 @@ update(){
     [ "$progress" -gt "$maxprogress" ] && return 255
     return 0
 }
-main_loop update
+main_loop "$@"

--- a/examples/wintest.sh
+++ b/examples/wintest.sh
@@ -61,10 +61,15 @@ main(){
         append "This is a simple\nlittle window"
     endwin
 
-    col_right
+   window "Other window" "blue" "11%"
+       append "And this is\nanother little window"
+       append "`date`"
+   endwin
+   
+   move_up
 
-    window "Other window" "blue" "22%"
-        append "And this is\nanother little window"
-    endwin
+   window "Bottom banner" "green" "100%"
+    append "The last window"
+   endwin
 }
-main_loop
+main_loop "$@"

--- a/simple_curses.sh
+++ b/simple_curses.sh
@@ -6,17 +6,17 @@
 #
 #create_buffer patch by Laurent Bachelier
 #
-#restriction to local variables and 
+#restriction to local variables and
 #rename variables to ones which will not collide
 #by Markus Mikkolainen
 #
 #support for bgcolors by Markus Mikkolainen
 #
-#support for delay loop function (instead of sleep, 
-#enabling keyboard input) by Markus Mikkolainen 
+#support for delay loop function (instead of sleep,
+#enabling keyboard input) by Markus Mikkolainen
+
 
 bsc_create_buffer(){
-    local BUFFER_DIR
     # Try to use SHM, then $TMPDIR, then /tmp
     if [ -d "/dev/shm" ]; then
         BUFFER_DIR="/dev/shm"
@@ -24,7 +24,8 @@ bsc_create_buffer(){
         BUFFER_DIR="$TMPDIR"
     else
         BUFFER_DIR="/tmp"
-    fi 
+    fi
+
     local buffername
     [[ "$1" != "" ]] &&  buffername=$1 || buffername="bashsimplecurses"
 
@@ -38,56 +39,79 @@ bsc_create_buffer(){
 }
 
 #Usefull variables
-BSC_LASTCOLS=0
-BSC_BUFFER=`bsc_create_buffer`
-BSC_POSX=0
-BSC_POSY=0
-BSC_LASTWINPOS=0
+BSC_BUFFER=$(bsc_create_buffer)
+BSC_STDERR=$(bsc_create_buffer stderr)
 
-#call on SIGINT and SIGKILL
-#it removes buffer before to stop
-bsc_on_kill(){
-    tput cup 0 0 >> $BSC_BUFFER
-    # Erase in-buffer
-    tput ed >> $BSC_BUFFER
+reset_layout() {
+    BSC_COLLFT=0
+    BSC_COLWIDTH=0
+    BSC_COLWIDTH_MAX=0
+    BSC_WLFT=0
+    # Height are not dynamically updated
+    # Only at window and endwin call
+    # Height of the current window
+    BSC_WNDHGT=0
+    # Height of the bottom of the current window
+    BSC_COLHGT=0
+    # Heigh of the bottom of the current column
+    BSC_COLBOT=0
+    # Height of the maximum bottom ever
+    BSC_COLHGT_MAX=0
+    # Flags to code the lib user window placement request
+    BSC_NEWWIN_TOP_REQ=0
+    BSC_NEWWIN_RGT_REQ=0
+}
+
+clean_env(){
     rm -rf $BSC_BUFFER
     reset_colors
     tput cnorm
-    exit 0
+    tput cvvis
+    setterm -cursor on
 }
-trap bsc_on_kill SIGINT SIGTERM
+#call on SIGINT and SIGKILL
+#it removes buffer before to stop
+bsc_on_kill(){
+    clean_env
+    exit 15
+}
 
+BSC_SIGINT=0
+bsc_flag_sigint()
+{
+    # Defer sigint processing because otherwise commands are pushed into BSC_BUFFER due to redirect in main_loop, which is deleted in clean_env ...
+    # This does not seem to be problematic with SIGKILL
+    # lets admit it this handling of SIGINT is tedious
+    BSC_SIGINT=1
+}
+trap bsc_on_kill SIGTERM
+trap bsc_flag_sigint SIGINT
 
 #initialize terminal
 bsc_term_init(){
-    BSC_POSX=0
-    BSC_POSY=0
-    tput clear >> $BSC_BUFFER
-    tput civis >> $BSC_BUFFER
+    if [ "$BSC_MODE" == dashboard ]; then
+        tput clear
+    fi
+    # tput civis
 }
 
 
 #change line
 bsc__nl(){
-    BSC_POSY=$((BSC_POSY+1))
-    tput cup $BSC_POSY $BSC_POSX >> $BSC_BUFFER
-    #echo 
+    BSC_WNDHGT=$((BSC_WNDHGT+1))
+    tput cud1
+    tput cub "$(tput cols)"
+    [ $BSC_WLFT -gt 0 ] && tput cuf $BSC_WLFT
+    tput sc
 }
 
 
-move_up(){
-    set_position $BSC_POSX 0
+function move_up(){
+    BSC_NEWWIN_TOP_REQ=1
 }
 
-col_right(){
-    left=$((BSC_LASTCOLS+BSC_POSX))
-    set_position $left $BSC_LASTWINPOS
-}
-
-#put display coordinates
-set_position(){
-    BSC_POSX=$1
-    BSC_POSY=$2
+function col_right(){
+    BSC_NEWWIN_RGT_REQ=1
 }
 
 #initialize chars to use
@@ -103,7 +127,7 @@ _DIAMOND="\033(00\033(B"
 _BLOCK="\033(01\033(B"
 _SPINNER=('-' '\' '|' '/')
 
-bsc_init_chars(){
+function bsc_init_chars() {
     if [[ -z "$BSC_ASCIIMODE" && $LANG =~ .*\.UTF-8 ]] ; then BSC_ASCIIMODE=utf8; fi
     if [[ "$BSC_ASCIIMODE" != "" ]]; then
         if [[ "$BSC_ASCIIMODE" == "ascii" ]]; then
@@ -133,62 +157,127 @@ bsc_init_chars(){
     fi
 }
 
+backtotoprow () {
+    local travelback
+    travelback=$1
 
-#Append a windo on BSC_POSX,BSC_POSY
-window(){
-    BSC_LASTWINPOS=$BSC_POSY
+    # Testing if layout would require non destructive scrolling
+    nbrows=$(tput lines)
+    scrollback=$(( travelback -nbrows ))
+    if [ $scrollback -gt 0 ]; then
+    #    tput rin $scrollback
+    #    travelback=$(( travelback - scrollback ))
+        echo "Warning: Current layout is exceeding terminal size. This will break window top alignment. Increase terminal height/reduce window content for proper rendering." >&2
+    fi
+    [ $travelback -gt 0 ] && tput cuu $travelback
+}
+
+#Append a window 
+function window() {
     local title
     local color
     local bgcolor
     title=$1
-    color=$2        
+    color=$2
     bgcolor=$4
-    tput cup $BSC_POSY $BSC_POSX 
+
+    [ $VERBOSE -eq 2 ] && echo "Begin of window $title" >&2
+
+    # Manage new window position
+    case "$BSC_NEWWIN_TOP_REQ$BSC_NEWWIN_RGT_REQ" in
+        "00" )
+        # Window is requested to be displayed under the previous one
+        ;;
+        "01" )
+        # Window is requested to be displayed to the right of the last one
+
+        BSC_WLFT=$(( BSC_WLFT + BSC_COLWIDTH ))
+        [ $BSC_WLFT -gt 0 ] && tput cuf $(( BSC_WLFT + BSC_COLWIDTH ))
+    backtotoprow $BSC_WNDHGT
+        BSC_COLHGT=$(( BSC_COLHGT - BSC_WNDHGT))
+        ;;
+        "10" )
+        # Window is requested to be displayed overwriting the ones above (??!??)
+        # Instead, we reset the layout, enabling more possibilities
+        tput cud $(( BSC_COLHGT_MAX - BSC_COLBOT ))
+        reset_layout
+        ;;
+        "11" )
+        # Window is requested to be displayed in a new column starting from top
+    backtotoprow $BSC_COLHGT
+        
+        BSC_COLLFT=$(( BSC_COLLFT + BSC_COLWIDTH_MAX ))
+        BSC_WLFT=$BSC_COLLFT
+
+        BSC_COLHGT=0
+        BSC_COLBOT=0
+        BSC_COLWIDTH_MAX=0
+        ;;
+        * )
+        echo "Unexpected window position requirement"
+        clean_env
+        exit 1
+    esac
+
+    # Reset window position mechanism for next window
+    BSC_NEWWIN_TOP_REQ=0
+    BSC_NEWWIN_RGT_REQ=0
+    BSC_WNDHGT=0
+
     bsc_cols=$(tput cols)
-    bsc_cols=$((bsc_cols))
-    if [[ "$3" != "" ]]; then
-        bsc_cols=$3
-        if [ $(echo $3 | grep "%") ];then
-            bsc_cols=$(tput cols)
-            bsc_cols=$((bsc_cols))
-            local w
+    case $3  in
+        "" )
+            # No witdh given
+        ;;
+        *% )
             w=$(echo $3 | sed 's/%//')
             bsc_cols=$((w*bsc_cols/100))
-        fi
+        ;;
+        * )
+            bsc_cols=$3
+        ;;
+    esac
+    
+    if [ "$bsc_cols" -lt 3 ]; then
+        echo "Column width of window \"$title\" is too narrow to render (sz=$bsc_cols)." >&2
+        exit 1;
     fi
+
+    BSC_COLWIDTH=$bsc_cols
+    [ $BSC_COLWIDTH -gt $BSC_COLWIDTH_MAX ] && BSC_COLWIDTH_MAX=$BSC_COLWIDTH
+
+    # Create an empty line for this window
+    BSC_BLANKLINE=$(head -c "$BSC_COLWIDTH" /dev/zero | tr '\0' ' ')
+    BSC_LINEBODY=${BSC_BLANKLINE:2}
+    contentLen=${#BSC_LINEBODY}
+    BSC_LINEBODY=${BSC_LINEBODY// /$_HLINE}
+
     local len
-    len=$(echo "$1" | echo $(($(wc -c)-1)))
-    bsc_left=$(((bsc_cols/2) - (len/2) -1))
+    len=${#title}
+
+    if [ $BSC_TITLECROP -eq 1 ] && [ "$len" -gt "$contentLen" ]; then
+        title="${title:0:$contentLen}"
+        len=${#title}
+    fi
+
+    bsc_left=$(( (bsc_cols - len)/2 -1 ))
+
+    # Init top left window corner
+    tput cub "$(tput cols)"
+    [ $BSC_WLFT -gt 0 ] && tput cuf $BSC_WLFT
+    tput sc
 
     #draw upper line
-    clean_line
-    echo -ne $_TL
-    local i
-    for i in `seq 3 $bsc_cols`; do echo -ne $_HLINE; done
-    echo -ne $_TR
+    echo -ne "$_TL$BSC_LINEBODY$_TR"
+
     #next line, draw title
     bsc__nl
+    append "$title" center "$color" "$bgcolor"
 
-    clean_line
-    echo -ne $_VLINE
-    tput cuf $bsc_left
-    #set title color
-    setcolor $color
-    setbgcolor $bgcolor
-    
-    echo $title
-    reset_colors
-    tput rc
-    tput cuf $((bsc_cols-1))
-    echo -ne $_VLINE
-    reset_colors
-    bsc__nl
     #then draw bottom line for title
     addsep
-    
-    BSC_LASTCOLS=$bsc_cols
-
 }
+
 reset_colors(){
     echo -ne "\033[00m"
 }
@@ -262,17 +351,13 @@ setbgcolor(){
     esac
 
 }
+
 #append a separator, new line
 addsep (){
     clean_line
-    echo -ne $_SEPL
-    local i
-    for i in `seq 3 $bsc_cols`; do echo -ne $_HLINE; done
-    reset_colors
-    echo -ne $_SEPR
+    echo -ne "$_SEPL$BSC_LINEBODY$_SEPR"
     bsc__nl
 }
-
 
 #clean the current line
 clean_line(){
@@ -280,25 +365,17 @@ clean_line(){
     reset_colors
 
     tput sc
+    echo -ne "$BSC_BLANKLINE"
     #tput el
     tput rc
 }
 
-
 #add text on current window
 append_file(){
-    local align
-    [[ "$1" != "" ]] && align="left" || align=$1
-    local l
-    IFS=''
-    while read l;do
-        l=`echo $l | sed 's/____SPACES____/ /g'`
-        l=$(echo $l |cut -c 1-$((BSC_LASTCOLS - 2)) )
-        bsc__append "$l" $align $2 $3
-    done < "$1"
-    unset IFS
-
-    reset_colors
+    local filetoprint
+    filetoprint=$1
+    shift
+    append_command "cat $filetoprint" "$@"
 }
 #
 #   blinkenlights <text> <color> <color2> <incolor> <bgcolor> <light1> [light2...]
@@ -314,7 +391,7 @@ blinkenlights(){
     text=$1
     color=$2
     color2=$3
-    incolor=$4  
+    incolor=$4
     bgcolor=$5
 
     declare -a params
@@ -336,12 +413,12 @@ blinkenlights(){
         params=( "${params[@]}" )
     done
 
-    bsc__multiappend "left" "[" $incolor $bgcolor $lights "]${text}" $incolor $bgcolor 
+    bsc__multiappend "left" "[" $incolor $bgcolor $lights "]${text}" $incolor $bgcolor
 }
 
 #
 #   vumeter <text> <width> <value> <max> [color] [color2] [inactivecolor] [bgcolor]
-#   
+#
 vumeter(){
     local done
     local todo
@@ -378,7 +455,7 @@ vumeter(){
     green=""
     red=""
     rest=""
-    
+
     for i in `seq 1 $(($done))`;do
         green="${green}|"
     done
@@ -408,11 +485,11 @@ progressbar(){
     len=$1
     progress=$2
     max=$3
-    
+ 
     done=$(( progress * len / max ))
     todo=$(( len - done - 1 ))
     modulo=$(( $(date +%s) % 4 ))
-    
+
     bar="[";
     for (( c=1; c<=done; c++ )); do
         bar="${bar}${_BLOCK}"
@@ -427,15 +504,9 @@ progressbar(){
     bsc__append "$bar" "left" $4 $5
 }
 append(){
-    text=$(echo -e "$1" | fold -w $((BSC_LASTCOLS-3)) -s)
-    rbuffer=`bsc_create_buffer bashsimplecursesfilebuffer`
-    echo  -e "$text" > $rbuffer
-
-    local a
-    while read a; do
-        bsc__append "$a" $2 $3 $4
-    done < $rbuffer
-    rm -f $rbuffer
+    while read -r line; do
+        bsc__append "$line" $2 $3 $4
+    done < <(echo -e "$1" | fold -w $((BSC_COLWIDTH-2)) -s)
 }
 #
 #   append a single line of text consisting of multiple
@@ -454,21 +525,21 @@ bsc__multiappend(){
         text="${text}${params[0]}"
         unset params[0]
         unset params[1]
-        unset params[2]    
+        unset params[2]
         params=( "${params[@]}" )
     done
     clean_line
     tput sc
     echo -ne $_VLINE
-    len=$(echo "$text" | wc -c )
-    len=$((len-1))
-    bsc_left=$((BSC_LASTCOLS/2 - len/2 -1))
-    
+    local len
+    len=$(wc -c < <(echo -n "$1"))
+    bsc_left=$(( (BSC_COLWIDTH - len)/2 - 1 ))
+
     params=( "$@")
     [[ "${params[0]}" == "left" ]] && bsc_left=0
     unset params[0]
     params=( "${params[@]}" )
-    tput cuf $bsc_left
+    [ $bsc_left -gt 0 ] && tput cuf $bsc_left
     while [ -n "${params}" ];do
         setcolor "${params[1]}"
         setbgcolor "${params[2]}"
@@ -480,7 +551,7 @@ bsc__multiappend(){
         params=( "${params[@]}" )
     done
     tput rc
-    tput cuf $((BSC_LASTCOLS-1))
+    tput cuf $((BSC_COLWIDTH-1))
     echo -ne $_VLINE
     bsc__nl
 }
@@ -492,19 +563,18 @@ bsc__append(){
     tput sc
     echo -ne $_VLINE
     local len
-    len=$(echo "$1" | wc -c )
-    len=$((len-1))
-    bsc_left=$((BSC_LASTCOLS/2 - len/2 -1))
-    
+    len=$(wc -c < <(echo -n "$1"))
+    bsc_left=$(( (BSC_COLWIDTH - len)/2 - 1 ))
+
     [[ "$2" == "left" ]] && bsc_left=0
 
-    tput cuf $bsc_left
+    [ $bsc_left -gt 0 ] && tput cuf $bsc_left
     setcolor $3
     setbgcolor $4
-    echo -e "$1"
+    echo -ne "$1"
     reset_colors
     tput rc
-    tput cuf $((BSC_LASTCOLS-1))
+    tput cuf $((BSC_COLWIDTH-1))
     echo -ne $_VLINE
     bsc__nl
 }
@@ -514,88 +584,178 @@ append_tabbed(){
     [[ $2 == "" ]] && echo "append_tabbed: Second argument needed" >&2 && exit 1
     [[ "$3" != "" ]] && delim=$3 || delim=":"
     clean_line
-    
+
     echo -ne $_VLINE
     local len
-    len=$(echo "$1" | wc -c )
-    len=$((len-1))
-    bsc_left=$((BSC_LASTCOLS/$2)) 
-    
+    len=$(wc -c < <(echo -n "$1"))
+    cell_wdt=$((BSC_COLWIDTH/$2))
+
     setcolor $4
     setbgcolor $5
     tput sc
 
-    local i 
+    local i
     for i in `seq 0 $(($2))`; do
         tput rc
-        tput cuf $((bsc_left*i+1))
-        echo "`echo $1 | cut -f$((i+1)) -d"$delim"`" | cut -c 1-$((bsc_left-3))
+        cell_offset=$((cell_wdt*i))
+        [ $cell_offset -gt 0 ] && tput cuf $cell_offset
+        echo -n "`echo -n $1 | cut -f$((i+1)) -d"$delim" | cut -c 1-$((cell_wdt-3))`"
     done
 
     tput rc
     reset_colors
-    tput cuf $((BSC_LASTCOLS-2))
+    tput cuf $((BSC_COLWIDTH-2))
     echo -ne $_VLINE
     bsc__nl
 }
 
 #append a command output
 append_command(){
-    local buff
-    buff=`bsc_create_buffer command`
-    echo -e "`$1`" 2>&1 | fold -w $((BSC_LASTCOLS - 2)) -s | sed 's/ /____SPACES____/g' > $buff
-    setcolor $2
-    setbgcolor $3
-    append_file $buff "left"
-    rm -f $buff
-    reset_colors
-}
+    while read -r line; do
+        bsc__append "$line" left $2 $3
+    done < <( $1 2>&1 | fold -w $((BSC_COLWIDTH-2)) -s)
+    }
 
 #close the window display
 endwin(){
-    clean_line
-    echo -ne $_BL
-    for i in `seq 3 $BSC_LASTCOLS`; do echo -ne $_HLINE; done
-    echo -ne $_BR
+    # Plot bottom line
+    echo -ne "$_BL$BSC_LINEBODY$_BR"
     bsc__nl
+
+    BSC_COLHGT=$(( BSC_COLHGT + BSC_WNDHGT ))
+
+    if [ $BSC_COLHGT -gt $BSC_COLBOT ]; then
+        BSC_COLBOT=$BSC_COLHGT
+    fi
+
+    if [ $BSC_COLBOT -gt $BSC_COLHGT_MAX ]; then
+        BSC_COLHGT_MAX=$BSC_COLBOT
+    fi
+    [ $VERBOSE -eq 2 ] && echo "End of window $title" >&2
 }
 
-#refresh display
-refresh (){
-    cat $BSC_BUFFER
-    echo "" > $BSC_BUFFER
+function usage() {
+    script_name=$(basename "$0")
+  cat <<EOF
+Usage: $script_name [options]
+
+Displays windows in a layout using commands. User defines a "main" function, then calls this script main loop. The current help presents the options of the main loop function, presentation mode and layout usage.
+
+General main_loop options:
+  -c, --crop: Title is spread over multiple lines if necessary. Usinc -c, the title will be cropped to fit in window width.
+  -h, --help: displays this help message.
+  -t, --time [t] : Sleep time, in seconds, when no "update" function has been defined, this option is used when calling the "update" function
+  -s, --scroll: set presentation to scrolling mode. See "Presentation mode section".
+  -q, --quiet: there will be no warning messages at all
+  -v, --verbose: add debug messages after the layout.
+
+Presentation mode:
+  The screen is either managed as a static dashboard (default) or scrolling mode. The later enables seeing older displays by scrolling back in the terminal emulator window.
+  In static mode, the window is cleared and the layout is reset to top left corner.
+  In scrolling mode, the window is not cleared and the layout is just reset to the left border, leaving older display available for reading.
+  Some window, like progress bar, loose their interest in scrolling mode, but are compatible.
+  In scrolling mode, new layout starts under the previous one. There is no screen clearing. In default, dashboard mode, the cursor is placed at the top left corner.
+
+Layout usage:
+  Start window creation using "window" function. Width can be direct and percent of the full display area. User can enter more than 100%, there is no consistency check, result in unpredictable.
+  End window creation using "endwin" function
+  Windows can only be placed next to each other using "col_right" and/or "move_up" functions. This leads to 4 possible placement:
+  - window under the previous one : start new window directly after endwin
+  - Window on the right of the previous one : use col_right
+  - Window on the right starting from first line : use col_right then move_up
+  - Start from the bottom of the current one, first row : use move_up
+  See examples, especially wintest.sh to see all possible usages.
+
+EOF
 }
 
-
+parse_args (){
+    BSC_MODE=dashboard
+    VERBOSE=1
+    BSC_TITLECROP=0
+    time=1
+    while [[ $# -gt 0 ]]; do
+        # shellcheck disable=SC2034
+        case "$1" in
+        -c | --crop )        BSC_TITLECROP=1; shift 1 ;;
+        -h | --help )        usage; exit 0 ;;
+        -q | --quiet )       VERBOSE=0; shift 1 ;;
+        -s | --scroll )      BSC_MODE=scroll; shift 1 ;;
+        -t | --time )        time=$2; shift 2 ;;
+        -V | --verbose )     VERBOSE=2; shift 1 ;;
+        -- ) return 0 ;;
+        * ) echo "Option $1 does not exist"; exit 1;;
+        esac
+    done
+}
 
 #main loop called
 main_loop (){
+    parse_args $@
+
     bsc_term_init
     bsc_init_chars
-    local time
-    local number_re
-    #everything starting with a number is a number
-    number_re='^[0-9]+.*$'
-    time=1
-    [[ "$1" == "" ]] || time=$1
-    while [[ 1 ]];do
-        tput cup 0 0 >> $BSC_BUFFER
-        tput il $(tput lines) >>$BSC_BUFFER
-        main >> $BSC_BUFFER 
-        tput cup $(tput lines) $(tput cols) >> $BSC_BUFFER 
-        refresh
-        if ! [[ $time =~ $number_re ]] ; then
-            #call function with name $time 
-            eval $time
-            retval=$?
-            [ "$retval" == "0" ] || {
-                reset_colors
-                exit $retval
-            }
-        else
-            sleep $time
-        fi   
-        BSC_POSX=0
-        BSC_POSY=0
+
+    # if an update function has been defined, use it. Or just sleep
+    if [ "$(type -t update)" == "function" ]; then
+        update_fn="update"
+    else
+        update_fn="sleep"
+    fi
+
+    # Capture screen size change in dashboard mode to clean it
+    if [ "$BSC_MODE" == dashboard ]; then
+        trap "tput clear" WINCH
+    fi
+
+    while true; do
+        reset_layout
+        echo -n "" > $BSC_BUFFER
+        rm -f $BSC_STDERR
+
+        if [ "$BSC_MODE" == dashboard ]; then
+            tput clear >> $BSC_BUFFER
+            tput cup 0 0 >> $BSC_BUFFER
+        fi
+
+        main >> $BSC_BUFFER 2>$BSC_STDERR
+
+        # Go under the higest column, from under the last displayed window
+        tput cud $(( BSC_COLHGT_MAX - BSC_COLBOT )) >> "$BSC_BUFFER"
+        tput cub "$(tput cols)" >> "$BSC_BUFFER"
+
+        sigint_check
+
+        # Display the buffer
+        cat $BSC_BUFFER
+    
+        [ $VERBOSE -gt 0 ] && [ -f "$BSC_STDERR" ] && cat $BSC_STDERR && rm $BSC_STDERR
+
+        $update_fn "$time"
+        retval=$?
+        if [ $retval -eq 255 ]; then
+                clean_env
+                exit "$retval"
+        fi
+
+        sigint_check
     done
 }
+# Calls to this function are placed so as to avoid stdout mangling
+sigint_check (){
+    if [ $BSC_SIGINT -eq 1 ]; then
+        clean_env
+        [ -f "$BSC_STDERR" ] && cat $BSC_STDERR && rm $BSC_STDERR
+        # https://mywiki.wooledge.org/SignalTrap
+        trap - INT
+        kill -s INT "$$"
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "This file is a library not meant to be run. Source it in a main script."
+    echo ""
+    usage
+    exit 1
+fi
+


### PR DESCRIPTION
New:
 - Made window positioning relative rather than X/Y absolute position.
 - Add argument parsing capabilities and help usage. Updated examples to show how to pass arguments from command line to internall call to main_loop function.
 - Add quiet and verbose mode. Error messages are captured and displayed under the layout.
 - Window title will be split over multiple lines if window is too narrow. It can also be cropped using option -c.
 - To keep a clean screen compared to absolute coordinate mode, terminal size change is captured.
 - The input/sleep callback must be named update (regression warning)
 - Fixes regarding text position in window (may change rendering)
 - Added a sanity check that the file was not run as a script.
 - Wrong coordination of move_up and col_right will not screw display.
 - Add 2 level option parsing to choice.sh example: 1st level for choice, 2nd level for simple_curses.sh main function

Fixes:
 - Many functions were >> BSC_BUFFER in sub-main functions.This is redundant with main >> BSC_BUFFER. They have been removed, which result in cleaner code.
 - Many cursor position changes were exposed to a movement of 1 if the argment was 0. This could lead to last char beeing overwritten by right border
 - First character on the left is displayed against the border (tput cuf 0 shifts one cell)
 - Fix tedious/bug-prone reading of multibyte keys (arrows) in choice.sh

Maintenance:
 - Simplify append_function to avoid writing a file.
 - Simplify append_command function, now uses bsc__append.
 - Simplify append_file, now uses "append_command cat $1"
 - Inlined small functions called only one time
 - append_command and append_function do not rely any more on a temporary file