### PR TITLE
Fix typo in usage() v -> V

### DIFF
--- a/simple_curses.sh
+++ b/simple_curses.sh
@@ -647,7 +647,7 @@ General main_loop options:
   -t, --time [t] : Sleep time, in seconds, when no "update" function has been defined, this option is used when calling the "update" function
   -s, --scroll: set presentation to scrolling mode. See "Presentation mode section".
   -q, --quiet: there will be no warning messages at all
-  -v, --verbose: add debug messages after the layout.
+  -V, --verbose: add debug messages after the layout.
 
 Presentation mode:
   The screen is either managed as a static dashboard (default) or scrolling mode. The later enables seeing older displays by scrolling back in the terminal emulator window.


### PR DESCRIPTION
The `usage()` function [has a typo](https://github.com/metal3d/bashsimplecurses/blob/054a04acfad902d4b35f57c0f719acf37ff16585/simple_curses.sh#L650) that says you cane make it verbose by passing in the a `-v` flag but it is actually `-V`.  