### PR TITLE
Fix grammar, spelling mistakes and 404 image links in Markdown documents

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Laurent Bachelier - Patches
 alejandrogallo - Patches
 Markus Mikkolainen - Patches(update function,blinkenlights,vumeter,progressbar)
 Pierre Mazein - Add scrolling capability, fixes, help, doc
+Jeremy (jtbx) - Documentation

--- a/INSTALL
+++ b/INSTALL
@@ -1,19 +1,15 @@
 
-Command lines begining by "$" are executed as normal user. Command lines with "#" are executed as root.
+Commands beginning with a "$" are executed as a standard user. Commands beginnning with a "#" have to be executed as root.
 
 
 Help can be shown with:
 $ make help
 
-To install bashsimplecurses, you could try
+To install Bash Simple Curses, run
 $ make install
 
-Then, if no error, you should do as root:
-$ su -
+Then, if no error appeared, run the same command as root:
 # make install
 
 To uninstall:
-$ su -
 # make uninstall
-
-

--- a/Makefile
+++ b/Makefile
@@ -6,31 +6,31 @@ VERSION=1.4
 
 
 all: test
-	@echo "If no error, you can now run make install"
+	@echo "If no error was displayed, you can run 'make install'"
 
 help:
 	@echo ""
 	@echo "Usage: make [test|install|uninstall] [LIBDIR=path]"
 	@echo ""
-	@echo "Try make test. If everything is ok, you can run make install as root"
+	@echo "Try make test. If everything is OK, run 'make install' as root."
 	@echo "You can set LIBDIR to a valid directory. Default is $(LIBDIR)"
 	@echo ""
-	@echo "You can remove installation using make uninstall as root"
+	@echo "You can uninstall Bash Simple Curses by running 'make uninstall' as root."
 	@echo ""
 
 install:
-	@echo "Install..."
+	@echo "Installing..."
 	@mkdir -p $(LIBDIR)
 	install -m655 simple_curses.sh $(LIBDIR)/simple_curses.sh
 	@echo "done"
 
 uninstall:
-	@echo "Removing library"
+	@echo "Removing..."
 	rm -rf $(LIBDIR)/simple_curses.sh
 	@echo "done"
 
 test:
-	@echo "Check if img2txt is installed"
+	@echo "Checking if img2txt is installed"
 	@which img2txt > /dev/null && echo -e "\033[32mOk\033[0m - you can use img2txt command to display images on window" || echo -e "\033[33mWarning\033[0m - You should install caca-utils or img2txt command"
 
 dist:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo ""
 	@echo "Usage: make [test|install|uninstall] [LIBDIR=path]"
 	@echo ""
-	@echo "Try make test. If everything is OK, run 'make install' as root."
+	@echo "Run 'make test'. If everything is OK, run 'make install' as root."
 	@echo "You can set LIBDIR to a valid directory. Default is $(LIBDIR)"
 	@echo ""
 	@echo "You can uninstall Bash Simple Curses by running 'make uninstall' as root."

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmetal3d%2Fbashsimplecurses.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmetal3d%2Fbashsimplecurses?ref=badge_shield)
                 
 
-"Bash simple curses" give you some basic functions to quickly create some windows on you terminal as Xterm, aterm, urxvt...
+Bash Simple Curses gives you some basic functions to quickly create windows on your terminal.
 
-An example is given: bashbar. Bashbar is a monitoring bar that you can integrate in tiling desktop (Xmonad, WMii...)
+An example is given: bashbar. Bashbar is a monitoring bar that you can integrate into tiling window managers.
 
-The goal of Bash Simple Curses is not done (not yet) to create very complete windows. It is only done to create some colored windows and display informations into.
+The (unfinished) goal of Bash Simple Curses is to create very complete windows. It is only done to create colored windows and display information into.
 
-To use library, you have to import library "simple_curses.sh" into you bash script:
+To use this library, you have to import "simple_curses.sh" into your bash script, like so:
 
 ```bash
 
@@ -32,9 +32,9 @@ main (){
 main_loop 1
 ```
 
-That's all... 
+That's all.
 
-Go into the project to have documentation about functions: 
+Visit the repository's documentation to learn about functions: 
 https://github.com/metal3d/bashsimplecurses
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bash Simple Curses gives you some basic functions to quickly create windows on y
 
 An example is given: bashbar. Bashbar is a monitoring bar that you can integrate into tiling window managers.
 
-The (unfinished) goal of Bash Simple Curses is to create very complete windows. It is only done to create colored windows and display information into.
+The (unfinished) goal of Bash Simple Curses is to create windows. It is only done to create colored windows and display information into.
 
 To use this library, you have to import "simple_curses.sh" into your bash script, like so:
 
@@ -20,15 +20,15 @@ To use this library, you have to import "simple_curses.sh" into your bash script
 #source /usr/lib/simple_curses.sh
 source /usr/local/lib/simple_curses.sh
 
-#Then, you must create a "main" function:
-main (){
-    #your code here, you can add some windows, text...
+# You must create a "main" function:
+main () {
+    # Your code here, here we add some windows and text
     window "title" "color"
     append "Text..."
     endwin
 }
 
-#then, you can execute loop:
+# Then, execute the loop
 main_loop 1
 ```
 

--- a/docs/BasicTutorial.md
+++ b/docs/BasicTutorial.md
@@ -1,34 +1,35 @@
 # Basic Introduction #
 
-Bash simple curses is a very simple bash library to create "bash windows" and append texts into.
+Bash Simple Curses is a very simple Bash library to create "bash windows" and append texts into.
 You only have to know some functions and what to show.
 
-Let's take a look on this little tutorial
+Let's take a look at this little tutorial.
 
 # Importing bash functions #
 
-Create a directory where we will work. For example
+Create a directory where we will work. For example:
 
 ```bash
 mkdir -p ~/tutorial/bashcurses
 ```
 
-Get bashsimplecurses sources from github.
+Clone the Bash Simple Curses GitHub repository.
 
 ```bash
 cd ~/tutorial/bashcurses
 git clone git@github.com:metal3d/bashsimplecurses.git
 ```
 
-Now, create a tutorial.sh script and edit it, you can use vim, gedit, nano...:
+Now, create a tutorial.sh script and edit it with your favourite editor:
 
 ```bash
 touch tutorial.sh
 #vim tutorial.sh
-#or nano tutorial.sh
+#nano tutorial.sh
+editor tutorial.sh
 ```
 
-It's ok, then you can add this:
+Now, add this:
 
 ```bash
 #!/bin/bash
@@ -42,11 +43,11 @@ main(){
    append "It's the content of my window"
    endwin
 }
-#then ask the standard loop
+#then call the standard loop
 main_loop
 ```
 
-Save your work. Now, you only have to set this script "executable"
+Save your work. Now, you have to make the script executable:
 
 ```bash
 chmod +x ~/tutorial/bashcurses/tutorial.sh
@@ -57,7 +58,7 @@ Now, you can try:
 ~/tutorial/bashcurses/tutorial.sh
 ```
 
-And a window appeaars ! To close your script, you only have to kill or press CTRL+C
+And a window appeaars! To close your script, you only have to kill the process, or press CTRL+C.
 
 ![http://www.metal3d.org/captures/bashsimplecurses/tuto1.png](http://www.metal3d.org/captures/bashsimplecurses/tuto1.png)
 
@@ -70,7 +71,7 @@ You can specify colors for titles. For example, change line on tutorial like thi
    window "Title of my window" "red"
 ```
 
-Restart your script, and the title is red.
+Now restart your script, and the title is red.
 
 ![http://www.metal3d.org/captures/bashsimplecurses/tuto2.png](http://www.metal3d.org/captures/bashsimplecurses/tuto2.png)
 
@@ -94,27 +95,27 @@ By default, windows take 100% of terminal width. You can specify number of cols 
    window "Title of my window" "red" 36
 ```
 
-This will set the width to 36 caracters (cols).
+This will set the width of the window to 36 characters.
 
-You may use percent:
+You can also use a percentage:
 
 ```
 window "Title of my window" "red" "50%"
 ```
 
-and the window takes 50% of the terminal width
+and now, the window takes up 50% of the terminal width.
 
 ## Functions reference ##
 
-This is the list of commands you can use:
+This is a list of commands you can use:
 
-  * **`window "TITLE" "COLOR" WIDTH`** = create a window with title, color and width
-  * **`append "TEXT"`** = append text to the window, be carefull "\n" are not interpreted, you have to append line by line
-  * **`append_tabbed "TEXT" COLS SEP`** = As "append" function but TEXT will be displayed as table. You need to give number of cols you will display. SEP is ":" by default
-  * **`append_file`** display a file text on window, text is wrapped to fit window
-  * **`tail_file "TAIL_OPTS"`** tail a file text or pipe to window, text is wrapped to fit window
-  * **`append_command`** Execute command and display result on window
-  * **`addsep`** = Append a separator
-  * **`main_loop SEC`** = run loop every SEC second, default is 1 second
+  * **`window "TITLE" "COLOR" WIDTH`**: Create a window with title, color and width.
+  * **`append "TEXT"`**: Append text to the window. Be careful, newline characters (`\n`) are not interpreted, you'll have to append line by line.
+  * **`append_tabbed "TEXT" COLS SEP`**: This is similar to the `append` function, but `TEXT` will be displayed as a table. You'll need to give the number of characters you will display. SEP is ":" by default.
+  * **`append_file`**: Display text from a file on a window. Text is wrapped to fit window.
+  * **`tail_file "TAIL_OPTS"`**: `tail` text from a file or pipe to a window. Text is wrapped to fit window.
+  * **`append_command`**: Execute a command and display the result on a window.
+  * **`addsep`**: Append a separator.
+  * **`main_loop SEC`**: Run a loop every SEC second, the default is 1 second.
 
-That's all folks !
+That's all folks!

--- a/docs/HowItWorks.md
+++ b/docs/HowItWorks.md
@@ -1,16 +1,16 @@
 # Introduction #
 
-Bash provides some command to make that kind of operations:
+Bash provides these features to make various operations:
 
-* tput command
-* STD redirection
-* escaped colors
+* `tput` command
+* STD* redirection
+* color escape codes
 
-Bash simple curses makes use of this commands to draw windows, change color, and so on.
+Bash Simple Curses makes use of these commands to draw windows, change color, and so on.
 
 ## Lines ##
 
-Lines and corners are display as "chars". You can try this:
+Lines and corners display as "chars". You can try this:
 
 ```bash
 echo -e "\033(0 l q k x m j \033(B"
@@ -20,39 +20,39 @@ You will see special chars that we use to create window borders.
 
 ## Placing cursor ##
 
-Because we need to write lines and texts on screen, `tput` command is used. `tput` can move cursor everywhere you want on terminal.
+Because we need to write lines and words on screen, `tput` is used. `tput` can move the cursor anywhere you'd like on the terminal.
 
 ## Colors ##
 
-Bash can change the text color using escaped values. For example
+Bash can change the text color using escape codes. For example
 
 ```bash
 echo -e "\033[32mText in red\033[0m"
 ```
 
-This line displays text in red color.
+This line displays red text.
 
 ## Buffer ##
 
-Tput command is a bit low... Refreshing view is not pretty while the cursor is moving on screen. A "clipping" appears. That's why Bash simple curses needs a STDOUT buffer that is not display until we explicitally ask to flush display.
+`tput` has a few problems. Refreshing view isn't pretty while the cursor is moving on screen; a "clipping" appears. That's why Bash Simple Curses needs a STDOUT buffer that won't display until we explicitly ask it to flush the display.
 
 Bash has no STDOUT buffer...
 
-So, to fix the buffering context, Bash simple curses redirects each "echo" command to a FIFO placed in /tmp/ or /dev/shm/ (depending on the OS).
+So, to fix the buffering context, Bash Simple Curses redirects each `echo` command to a FIFO placed in /tmp or /dev/shm (depending on the OS).
 
-This buffer is flushed when "refresh" (internal) command is called. This is executed automatically by bashsimplecurses.
+This buffer is flushed when "refresh" (internal) command is called. This is executed automatically by Bash Simple Curses.
 
-## What's happend ? ##
+## What's happened? ##
 
-Everything is done when you have call `main_loop` function. This makes:
+Everything is done when you call the `main_loop` function. This does the following:
 
 * clean screen
 * place cursor on top
 * initiate buffer
 
-When you create a "window", a title is set with color and size. Size is kept to set content with same width.
+When you create a "window", a title is set with a color and size. The size is kept to set content with same width.
 
-Everytime you call "window" or "append", a basic method is called to place text on center.
-Then "endwin" close window.
+Everytime you call `window` or `append`, a basic method is called to place text on center.
+After that, `endwin` closes the window.
 
-`main_loop` sends outuput to the buffer file, when everything on "main" function is done, `main_loop` displays buffer, then clean it.
+`main_loop` sends output to the buffer file. When everything in the `main` function is done, `main_loop` displays the buffer, then cleans it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,15 +6,17 @@ An example is given: bashbar. Bashbar is a monitoring bar that you can integrate
 
 The (unfinished) goal of Bash Simple Curses is to create very complete windows. It is only made to create colored windows and display information into.
 
-# Why ? #
+# Why? #
 
-Bash is very complete and has a great ecosystem; there are commands to do whatever you want. With `curses` you can create a little bar to display information each second, you can change an output command to display a report, etc.
+Bash is very complete and has a great ecosystem; there are commands to do whatever you want. With `curses` you can create a little bar to display information each second, or you can change an output command to display a report, etc.
 
-So, we need an easy and useful library to quickly create this kind of views inside of Bash. This is why Bash Simple Curses exists.
+We need a simple and useful library to quickly create these kind of views inside of Bash. This is why Bash Simple Curses exists.
 
-# Example: the bashbar #
+# Example: bashbar #
 
 Bashbar is the given example that shows system information. You only have to resize your terminal window and place it on the left or on the right. This screenshot is made on Xmonad:
+
+![http://www.metal3d.org/captures/bashsimplecurses/bashbar.png](http://www.metal3d.org/captures/bashsimplecurses/bashbar.png)
 
 This is how it's implemented:
 
@@ -37,7 +39,7 @@ main (){
     append_tabbed `cat /proc/meminfo | awk '/MemFree/ {print "Used:" $2/1024}'` 2
     endwin
 
-    window "Processus taking memory and CPU" "green"
+    window "Processes taking memory and CPU" "green"
     for i in `seq 2 6`; do
         append_tabbed "`ps ax -o pid,rss,pcpu,ucmd --sort=-cpu,-rss | sed -n "$i,$i p" | awk '{printf "%s: %smo:  %s%%" , $4, $2/1024, $3 }'`" 3
     done
@@ -61,11 +63,13 @@ main (){
 main_loop 1
 ```
 
-# Another Example #
+# Another example #
 
-This capture shows you that you can do whatever you want with Bash Simple Curses:
+This picture shows you that you can do whatever you wish with Bash Simple Curses:
 
-Code is:
+![http://www.metal3d.org/captures/bashsimplecurses/bashcurses.png](http://www.metal3d.org/captures/bashsimplecurses/bashcurses.png)
+
+Code:
 
 ```bash
 #!/bin/bash
@@ -115,5 +119,7 @@ main_loop
 # Other cool ideas #
 
 With `img2txt` from the libcaca library, you can do something like this:
+
+![http://www.metal3d.org/captures/bashsimplecurses/bashcurses_windows.png](http://www.metal3d.org/captures/bashsimplecurses/bashcurses_windows.png)
 
 Cool, isn't it?

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,24 @@
 # The simple way #
 
-"Bash simple curses" provides some basic functions to quickly create some windows on you terminal as Xterm, aterm, urxvt...
+Bash Simple Curses gives you some basic functions to quickly create windows on your terminal.
 
-An example is given: bashbar that is a monitoring bar you can integrate in tiling desktop (Xmonad, WMii...).
+An example is given: bashbar. Bashbar is a monitoring bar that you can integrate into tiling window managers.
 
-The goal of Bash Simple Curses is not creating very complete windows. It is only made to create some colored windows and display informations into.
+The (unfinished) goal of Bash Simple Curses is to create very complete windows. It is only made to create colored windows and display information into.
 
 # Why ? #
 
-Bash is very comple and has a great ecosystem, there are commands to do whatever you want. With curses you can create a little bar to display informations each second, you can change an output command to display a report...
+Bash is very complete and has a great ecosystem; there are commands to do whatever you want. With `curses` you can create a little bar to display information each second, you can change an output command to display a report, etc.
 
-So, we need an easy and usefull library to quickly create this kind of views. This is why you can try Bash Simple Curses.
+So, we need an easy and useful library to quickly create this kind of views inside of Bash. This is why Bash Simple Curses exists.
 
 # Example: the bashbar #
 
-Bash bar is the given example that show system informations. You only have to resize your terminal window and place it on left or right. This screenshot is made on Xmonad:
+Bashbar is the given example that shows system information. You only have to resize your terminal window and place it on the left or on the right. This screenshot is made on Xmonad:
 
-![http://www.metal3d.org/captures/bashsimplecurses/bashbar.png](http://www.metal3d.org/captures/bashsimplecurses/bashbar.png)
+*The screenshot provided before this commit just gives a 404.*
 
-It's implemented this way:
+This is how it's implemented:
 
 ```bash
 #!/bin/bash
@@ -65,9 +65,9 @@ main_loop 1
 
 # Another Example #
 
-this capture shows you that you can do whatever you want:
+This capture shows you that you can do whatever you want with Bash Simple Curses:
 
-![http://www.metal3d.org/captures/bashsimplecurses/bashcurses.png](http://www.metal3d.org/captures/bashsimplecurses/bashcurses.png)
+*Again, the screenshot provided before this commit just gives a 404.*
 
 Code is:
 
@@ -116,10 +116,10 @@ main(){
 main_loop
 ```
 
-# Some other cool stuffs #
+# Other cool ideas #
 
-And just with libcaca "img2txt" command, you can have fun:
+With `img2txt` from the libcaca library, you can do something like this:
 
-![http://www.metal3d.org/captures/bashsimplecurses/bashcurses_windows.png](http://www.metal3d.org/captures/bashsimplecurses/bashcurses_windows.png)
+*Once again, the screenshot provided before this commit just gives a 404.*
 
-Cool, isn't it ?
+Cool, isn't it?

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,6 @@ So, we need an easy and useful library to quickly create this kind of views insi
 
 Bashbar is the given example that shows system information. You only have to resize your terminal window and place it on the left or on the right. This screenshot is made on Xmonad:
 
-*The screenshot provided before this commit just gives a 404.*
-
 This is how it's implemented:
 
 ```bash
@@ -66,8 +64,6 @@ main_loop 1
 # Another Example #
 
 This capture shows you that you can do whatever you want with Bash Simple Curses:
-
-*Again, the screenshot provided before this commit just gives a 404.*
 
 Code is:
 
@@ -119,7 +115,5 @@ main_loop
 # Other cool ideas #
 
 With `img2txt` from the libcaca library, you can do something like this:
-
-*Once again, the screenshot provided before this commit just gives a 404.*
 
 Cool, isn't it?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Bash simple curses
+site_name: Bash Simple Curses
 theme: readthedocs
 pages:
 - [index.md]
 - [BasicTutorial.md, "Tutorial"]
-- [HowItWorks.md, "How does it works"]
+- [HowItWorks.md, "How it works"]


### PR DESCRIPTION
This PR fixes grammar and spelling mistakes in README.md, docs/BasicTutorial.md, docs/HowItWorks.md, and docs/index.md.

Closes #43

\- Jeremy
