### PR TITLE
initialize global variables at the begining

### DIFF
--- a/simple_curses.sh
+++ b/simple_curses.sh
@@ -15,6 +15,26 @@
 #support for delay loop function (instead of sleep,
 #enabling keyboard input) by Markus Mikkolainen
 
+BSC_COLLFT=0
+BSC_COLWIDTH=0
+BSC_COLWIDTH_MAX=0
+BSC_WLFT=0
+# Height are not dynamically updated
+# Only at window and endwin call
+# Height of the current window
+BSC_WNDHGT=0
+# Height of the bottom of the current window
+BSC_COLHGT=0
+# Heigh of the bottom of the current column
+BSC_COLBOT=0
+# Height of the maximum bottom ever
+BSC_COLHGT_MAX=0
+# Flags to code the lib user window placement request
+BSC_NEWWIN_TOP_REQ=0
+BSC_NEWWIN_RGT_REQ=0
+VERBOSE=0
+BSC_TITLECROP=0
+
 VERSION="dev"
 
 bsc_create_buffer(){


### PR DESCRIPTION
a simple app which just want to show some data in a list fails due to some of the variables are not initialized. to overcome this initialize the vars in the begining

here is an example script which fails without this fix. comments starting with # are marked as \# in this

\#!/bin/bash

source ../bashsimplecurses/simple_curses.sh

file=main.c

command_output() {
  \# Capture the output of the command
  output=$(find ./ -name $file* | grep -v "\.git"| cat -n)
  \# Display the output in the window
  echo "$output"
}

show_win() {
  \# Initialize the screen
  window "window" "blue"
  count=`find ./ -name $file* | grep -v "\.git"| wc -l`
  append "total numbers: $count"
  addsep
  \# Call the command_output function to display the content
  append_command "command_output"
  \# Display the window
  endwin
}

\# Run the show_win function
show_win

echo "done"